### PR TITLE
Custom gibbs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v1.7.0 ()
+----------------------
+- Added custom sampler feature.  Interface requires creation of a class, but allows for inclusion of things like Gibbs samplers.
+
 v1.6.0 (August 31, 2018)
 ----------------------
 - Added optimal handling of prior function used numpy array multiplication.

--- a/pymcmcstat/MCMC.py
+++ b/pymcmcstat/MCMC.py
@@ -70,6 +70,7 @@ class MCMC:
         self.model_settings = ModelSettings()
         self.simulation_options = SimulationOptions()
         self.parameters = ModelParameters()
+        self.custom_samplers = None
         # private variables
         self._error_variance = ErrorVarianceEstimator()
         self._covariance = CovarianceProcedures()

--- a/pymcmcstat/MCMC.py
+++ b/pymcmcstat/MCMC.py
@@ -385,10 +385,9 @@ class MCMC:
             * **savecount** (:py:class:`int`): Reset save counter
             * **lastbin** (:py:class:`int`): Last index saved
         '''
-        savedir = self.simulation_options.savedir
-        ChainProcessing._check_directory(savedir)
-        
         if self.simulation_options.save_to_bin is True:
+            savedir = self.simulation_options.savedir
+            ChainProcessing._check_directory(savedir)
             if append_to_log is True:
                 binlogfile = os.path.join(savedir, 'binlogfile.txt')
                 binstr = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
@@ -396,6 +395,8 @@ class MCMC:
             self.__save_chains(chains = chains, savedir = savedir, start = start, end = end, extension = 'h5')
             
         if self.simulation_options.save_to_txt is True:
+            savedir = self.simulation_options.savedir
+            ChainProcessing._check_directory(savedir)
             if append_to_log is True:
                 txtlogfile = os.path.join(savedir, 'txtlogfile.txt')
                 txtstr = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')

--- a/pymcmcstat/MCMC.py
+++ b/pymcmcstat/MCMC.py
@@ -70,7 +70,7 @@ class MCMC:
         self.model_settings = ModelSettings()
         self.simulation_options = SimulationOptions()
         self.parameters = ModelParameters()
-        self.custom_samplers = None
+        self.custom_samplers = []
         # private variables
         self._error_variance = ErrorVarianceEstimator()
         self._covariance = CovarianceProcedures()
@@ -196,6 +196,12 @@ class MCMC:
         
         if self.simulation_options.ntry > 1:
             self._sampling_methods.delayed_rejection._initialize_dr_metrics(self.simulation_options)
+        # ---------------------
+        # Setup custom samplers
+        if self.custom_samplers is not None:
+            for ii, cs in enumerate(self.custom_samplers):
+                cs.setup()
+        
     # --------------------------------------------------------
     def __initialize_chains(self, chainind, nsimu, npar, nsos, updatesigma, sigma2):
         '''
@@ -312,6 +318,12 @@ class MCMC:
             # SAVE TO LOG FILE
             if savecount == self.simulation_options.savesize:
                 savecount, lastbin = self.__save_to_log_file(start = isimu - self.simulation_options.savesize, end = isimu)
+                
+            # ---------------------
+            # RUN CUSTOM SAMPLERS
+            if self.custom_samplers is not None:
+                for ii, cs in enumerate(self.custom_samplers):
+                    cs.update()
        
         # SAVE REMAINING ELEMENTS TO BIN FILE
         self.__save_to_log_file(start = lastbin, end = isimu + 1)

--- a/pymcmcstat/MCMC.py
+++ b/pymcmcstat/MCMC.py
@@ -326,19 +326,18 @@ class MCMC:
                     
             # SAVE TO LOG FILE
             if savecount == self.simulation_options.savesize:
-                savecount, lastbin = self.__save_to_log_file(start = isimu - self.simulation_options.savesize, end = isimu)
+                savecount, lastbin = self.__save_to_log_file(chains = self.__chains, start = isimu - self.simulation_options.savesize, end = isimu)
                 # add custom chains is applicable
                 for cs in self.custom_samplers:
                     if (hasattr(cs, 'save_chain') is True) and (cs.save_chain is True):
-                        self.save_to_log_file(chains = cs.chains, start = isimu - self.simulation_options.savesize, end = isimu, append_to_log = False)
+                        self.__save_to_log_file(chains = cs.chains, start = isimu - self.simulation_options.savesize, end = isimu, append_to_log = False)
        
         # SAVE REMAINING ELEMENTS TO BIN FILE
-#        self.__save_to_log_file(start = lastbin, end = isimu + 1)
-        self.save_to_log_file(chains = self.__chains, start = lastbin, end = isimu + 1)
+        self.__save_to_log_file(chains = self.__chains, start = lastbin, end = isimu + 1)
         # add custom chains is applicable
         for cs in self.custom_samplers:
             if (hasattr(cs, 'save_chain') is True) and (cs.save_chain is True):
-                self.save_to_log_file(cs.chains, start = lastbin, end = isimu + 1, append_to_log = False)
+                self.__save_to_log_file(cs.chains, start = lastbin, end = isimu + 1, append_to_log = False)
        
         # update value to end value
         self.parameters._value[self.parameters._parind] = self.__old_set.theta
@@ -372,31 +371,9 @@ class MCMC:
         self.simulation_results.add_chain(chain = self.__chain)
         self.simulation_results.add_s2chain(s2chain = self.__s2chain)
         self.simulation_results.add_sschain(sschain = self.__sschain)
+
     # ------------------------------------------------
-    def __save_to_log_file(self, start, end):
-        '''
-        Save to log files
-        
-        Args:
-            * **start** (:py:class:`int`): Start index of chain block to save
-            * **end** (:py:class:`int`): End index of chain block to save
-            
-        Returns:
-            * **savecount** (:py:class:`int`): Reset save counter
-            * **lastbin** (:py:class:`int`): Last index saved
-        '''
-        if self.simulation_options.save_to_bin is True:
-            self.__save_chains_to_bin(start, end)
-        if self.simulation_options.save_to_txt is True:
-            self.__save_chains_to_txt(start, end)
-            
-        # reset counter
-        savecount = 0
-        lastbin = end
-        return savecount, lastbin
-    
-    # ------------------------------------------------
-    def save_to_log_file(self, chains, start, end, append_to_log = True):
+    def __save_to_log_file(self, chains, start, end, append_to_log = True):
         '''
         Save to log files
         

--- a/pymcmcstat/MCMC.py
+++ b/pymcmcstat/MCMC.py
@@ -524,7 +524,7 @@ class MCMC:
         self.__rejected['in_adaptation_interval'] += 1
         if outsidebounds:
             self.__rejected['outside_bounds'] += 1
-    # --------------------------------------------------------        
+    # --------------------------------------------------------
     def display_current_mcmc_settings(self):
         '''
         Display model settings, simulation options, and current covariance values.

--- a/pymcmcstat/settings/ModelParameters.py
+++ b/pymcmcstat/settings/ModelParameters.py
@@ -65,9 +65,19 @@ class ModelParameters:
             theta0 = 1.0
 
         # append dictionary element
-        self.parameters.append({'name': name, 'theta0': theta0, 'minimum': minimum,
-                                'maximum': maximum, 'prior_mu': prior_mu, 'prior_sigma': prior_sigma,
-                                'sample': bool(sample), 'local': local, 'adapt': bool(adapt)})
+        self.parameters.append(dict(
+                name = name,
+                theta0 = theta0,
+                minimum = minimum,
+                maximum = maximum,
+                prior_mu = prior_mu,
+                prior_sigma = prior_sigma,
+                sample = bool(sample),
+                local = local,
+                adapt = bool(adapt),
+                )
+        )
+        
     # --------------------------
     def _openparameterstructure(self, nbatch):
         # unpack input object

--- a/pymcmcstat/settings/SimulationOptions.py
+++ b/pymcmcstat/settings/SimulationOptions.py
@@ -25,7 +25,7 @@ class SimulationOptions:
 
     def define_simulation_options(self, nsimu=int(1e4), adaptint = None, ntry = None, method='dram',
                  printint=None, adaptend = 0, lastadapt = 0, burnintime = 0,
-                 waitbar = 1, debug = 0, qcov = None, updatesigma = False,
+                 waitbar = True, debug = 0, qcov = None, updatesigma = False,
                  stats = 0, drscale = np.array([5, 4, 3], dtype = float),
                  adascale = None, savesize = 0, maxmem = 0, chainfile = 'chainfile',
                  s2chainfile = 's2chainfile', sschainfile = 'sschainfile', covchainfile = 'covchainfile', savedir = None,
@@ -116,7 +116,7 @@ class SimulationOptions:
             self.doram = doram
         
         
-        self.nsimu = nsimu  # length of chain to simulate
+        self.nsimu = int(nsimu)  # length of chain to simulate
         self.method = method
         self.dodram = 0
         
@@ -124,11 +124,11 @@ class SimulationOptions:
         self.adaptend = adaptend  # last adapt
         self.lastadapt = lastadapt # last adapt
         self.burnintime = burnintime
-        self.waitbar = waitbar # use waitbar
+        self.waitbar = bool(waitbar) # use waitbar
         self.debug = debug  # show some debug information
         self.qcov = qcov  # proposal covariance
         self.initqcovn = initqcovn  # proposal covariance weight in update
-        self.updatesigma = updatesigma  #
+        self.updatesigma = bool(updatesigma)  #
         self.priorupdatestart = priorupdatestart
         self.qcov_adjust = qcov_adjust  # eps adjustment
         self.burnin_scale = burnin_scale

--- a/test/chain/test_ChainProcessing.py
+++ b/test/chain/test_ChainProcessing.py
@@ -205,7 +205,7 @@ class PrintLogFiles(unittest.TestCase):
         sys.stdout = sys.__stdout__
         
         self.assertTrue(isinstance(capturedOutput.getvalue(), str), msg = 'Should contain a string')
-        self.assertTrue('Display log file:' in capturedOutput.getvalue(), msg = 'Expect string to contain these works')
+        self.assertTrue('Display log file:' in capturedOutput.getvalue(), msg = 'Expect string to contain these words')
         shutil.rmtree(savedir)
 # -------------------------
 def setup_pres():

--- a/test/test_MCMC.py
+++ b/test/test_MCMC.py
@@ -233,6 +233,25 @@ class GenerateSimulationResults(unittest.TestCase):
         for cft in check_for_these:
             self.assertTrue(cft in results, msg = str('{} assigned successfully'.format(cft)))
             
+## ------------------------------------------------
+#class SaveToLogFile(unittest.TestCase):
+#    @patch('pymcmcstat.MCMC.MCMC._MCMC__save_chains_to_bin', return_value = None)
+#    def test_save_to_log_file_bin(self, mock_bin):
+#        mcstat = gf.basic_mcmc()
+#        mcstat.simulation_options.save_to_bin = True
+#        mcstat.simulation_options.save_to_txt = False
+#        savecount, lastbin = mcstat._MCMC__save_to_log_file(start = 0, end = 100)
+#        self.assertEqual(savecount, 0, msg = 'Expect 0')
+#        self.assertEqual(lastbin, 100, msg = 'Expect lastbin = end = 100')
+#        
+#    @patch('pymcmcstat.MCMC.MCMC._MCMC__save_chains_to_txt', return_value = None)
+#    def test_save_to_log_file_txt(self, mock_txt):
+#        mcstat = gf.basic_mcmc()
+#        mcstat.simulation_options.save_to_bin = False
+#        mcstat.simulation_options.save_to_txt = True
+#        savecount, lastbin = mcstat._MCMC__save_to_log_file(start = 0, end = 100)
+#        self.assertEqual(savecount, 0, msg = 'Expect 0')
+#        self.assertEqual(lastbin, 100, msg = 'Expect lastbin = end = 100')
 # ------------------------------------------------
 class SaveToLogFile(unittest.TestCase):
     @patch('pymcmcstat.MCMC.MCMC._MCMC__save_chains_to_bin', return_value = None)
@@ -240,7 +259,9 @@ class SaveToLogFile(unittest.TestCase):
         mcstat = gf.basic_mcmc()
         mcstat.simulation_options.save_to_bin = True
         mcstat.simulation_options.save_to_txt = False
-        savecount, lastbin = mcstat._MCMC__save_to_log_file(start = 0, end = 100)
+        chains = []
+        chains.append(dict(file = 'chain', mtx = np.random.random_sample((1000,3))))
+        savecount, lastbin = mcstat._MCMC__save_to_log_file(chains = chains, start = 0, end = 100)
         self.assertEqual(savecount, 0, msg = 'Expect 0')
         self.assertEqual(lastbin, 100, msg = 'Expect lastbin = end = 100')
         
@@ -249,9 +270,46 @@ class SaveToLogFile(unittest.TestCase):
         mcstat = gf.basic_mcmc()
         mcstat.simulation_options.save_to_bin = False
         mcstat.simulation_options.save_to_txt = True
-        savecount, lastbin = mcstat._MCMC__save_to_log_file(start = 0, end = 100)
+        chains = []
+        chains.append(dict(file = 'chain', mtx = np.random.random_sample((1000,3))))
+        savecount, lastbin = mcstat._MCMC__save_to_log_file(chains = chains, start = 0, end = 100)
         self.assertEqual(savecount, 0, msg = 'Expect 0')
         self.assertEqual(lastbin, 100, msg = 'Expect lastbin = end = 100')
+    
+    @patch('pymcmcstat.MCMC.MCMC._MCMC__save_chains_to_bin', return_value = None)
+    def test_save_to_log_file_bin_no_append(self, mock_bin):
+        mcstat = gf.basic_mcmc()
+        mcstat.simulation_options.save_to_bin = True
+        mcstat.simulation_options.save_to_txt = False
+
+        tmpfolder = gf.generate_temp_folder()
+        mcstat.simulation_options.savedir = tmpfolder
+        tmpfile = tmpfolder + os.sep + 'binlogfile.txt'
+        
+        chains = []
+        chains.append(dict(file = 'chain', mtx = np.random.random_sample((1000,3))))
+        savecount, lastbin = mcstat._MCMC__save_to_log_file(chains = chains, start = 0, end = 100, append_to_log = False)
+        
+        self.assertFalse(os.path.isfile(tmpfile), msg = str('File exists: {}'.format(tmpfile)))
+        shutil.rmtree(tmpfolder)
+        
+    @patch('pymcmcstat.MCMC.MCMC._MCMC__save_chains_to_txt', return_value = None)
+    def test_save_to_log_file_txt_no_append(self, mock_txt):
+        mcstat = gf.basic_mcmc()
+        mcstat.simulation_options.save_to_bin = False
+        mcstat.simulation_options.save_to_txt = True
+
+        tmpfolder = gf.generate_temp_folder()
+        mcstat.simulation_options.savedir = tmpfolder
+        tmpfile = tmpfolder + os.sep + 'txtlogfile.txt'
+        
+        chains = []
+        chains.append(dict(file = 'chain', mtx = np.random.random_sample((1000,3))))
+        savecount, lastbin = mcstat._MCMC__save_to_log_file(chains = chains, start = 0, end = 100, append_to_log = False)
+        
+        self.assertFalse(os.path.isfile(tmpfile), msg = str('File exists: {}'.format(tmpfile)))
+        shutil.rmtree(tmpfolder)
+        
 # --------------------------------------------------------
 class SaveChainsToTXT(unittest.TestCase):
     def run_chain_check(self, chainfile, sschainfile, covchainfile, s2chainfile, mcstat):

--- a/test/test_MCMC.py
+++ b/test/test_MCMC.py
@@ -232,49 +232,50 @@ class GenerateSimulationResults(unittest.TestCase):
         check_for_these = ['simulation_options', 'model_settings', 'chain', 's2chain', 'sschain', 'drscale', 'iacce', 'RDR']
         for cft in check_for_these:
             self.assertTrue(cft in results, msg = str('{} assigned successfully'.format(cft)))
-            
-## ------------------------------------------------
-#class SaveToLogFile(unittest.TestCase):
-#    @patch('pymcmcstat.MCMC.MCMC._MCMC__save_chains_to_bin', return_value = None)
-#    def test_save_to_log_file_bin(self, mock_bin):
-#        mcstat = gf.basic_mcmc()
-#        mcstat.simulation_options.save_to_bin = True
-#        mcstat.simulation_options.save_to_txt = False
-#        savecount, lastbin = mcstat._MCMC__save_to_log_file(start = 0, end = 100)
-#        self.assertEqual(savecount, 0, msg = 'Expect 0')
-#        self.assertEqual(lastbin, 100, msg = 'Expect lastbin = end = 100')
-#        
-#    @patch('pymcmcstat.MCMC.MCMC._MCMC__save_chains_to_txt', return_value = None)
-#    def test_save_to_log_file_txt(self, mock_txt):
-#        mcstat = gf.basic_mcmc()
-#        mcstat.simulation_options.save_to_bin = False
-#        mcstat.simulation_options.save_to_txt = True
-#        savecount, lastbin = mcstat._MCMC__save_to_log_file(start = 0, end = 100)
-#        self.assertEqual(savecount, 0, msg = 'Expect 0')
-#        self.assertEqual(lastbin, 100, msg = 'Expect lastbin = end = 100')
+
 # ------------------------------------------------
 class SaveToLogFile(unittest.TestCase):
     @patch('pymcmcstat.MCMC.MCMC._MCMC__save_chains_to_bin', return_value = None)
-    def test_save_to_log_file_bin(self, mock_bin):
+    def test_no_save_to_log_file(self, mock_bin):
         mcstat = gf.basic_mcmc()
-        mcstat.simulation_options.save_to_bin = True
+        mcstat.simulation_options.save_to_bin = False
         mcstat.simulation_options.save_to_txt = False
+        tmpfolder = gf.generate_temp_folder()
+        mcstat.simulation_options.savedir = tmpfolder
         chains = []
         chains.append(dict(file = 'chain', mtx = np.random.random_sample((1000,3))))
         savecount, lastbin = mcstat._MCMC__save_to_log_file(chains = chains, start = 0, end = 100)
         self.assertEqual(savecount, 0, msg = 'Expect 0')
         self.assertEqual(lastbin, 100, msg = 'Expect lastbin = end = 100')
+        self.assertFalse(os.path.isdir(tmpfolder), msg = str('Folder exists: {}'.format(tmpfolder)))
+        
+    @patch('pymcmcstat.MCMC.MCMC._MCMC__save_chains_to_bin', return_value = None)
+    def test_save_to_log_file_bin(self, mock_bin):
+        mcstat = gf.basic_mcmc()
+        mcstat.simulation_options.save_to_bin = True
+        mcstat.simulation_options.save_to_txt = False
+        tmpfolder = gf.generate_temp_folder()
+        mcstat.simulation_options.savedir = tmpfolder
+        chains = []
+        chains.append(dict(file = 'chain', mtx = np.random.random_sample((1000,3))))
+        savecount, lastbin = mcstat._MCMC__save_to_log_file(chains = chains, start = 0, end = 100)
+        self.assertEqual(savecount, 0, msg = 'Expect 0')
+        self.assertEqual(lastbin, 100, msg = 'Expect lastbin = end = 100')
+        shutil.rmtree(tmpfolder)
         
     @patch('pymcmcstat.MCMC.MCMC._MCMC__save_chains_to_txt', return_value = None)
     def test_save_to_log_file_txt(self, mock_txt):
         mcstat = gf.basic_mcmc()
         mcstat.simulation_options.save_to_bin = False
         mcstat.simulation_options.save_to_txt = True
+        tmpfolder = gf.generate_temp_folder()
+        mcstat.simulation_options.savedir = tmpfolder
         chains = []
         chains.append(dict(file = 'chain', mtx = np.random.random_sample((1000,3))))
         savecount, lastbin = mcstat._MCMC__save_to_log_file(chains = chains, start = 0, end = 100)
         self.assertEqual(savecount, 0, msg = 'Expect 0')
         self.assertEqual(lastbin, 100, msg = 'Expect lastbin = end = 100')
+        shutil.rmtree(tmpfolder)
     
     @patch('pymcmcstat.MCMC.MCMC._MCMC__save_chains_to_bin', return_value = None)
     def test_save_to_log_file_bin_no_append(self, mock_bin):
@@ -385,13 +386,15 @@ class RunSimulation(unittest.TestCase):
         mcstat.simulation_options.nsimu = 100
         mcstat.simulation_options.save_to_bin = False
         mcstat.simulation_options.save_to_txt = False
+        tmpfolder = gf.generate_temp_folder()
+        mcstat.simulation_options.savedir = tmpfolder
         mcstat.run_simulation()
         self.assertTrue(mcstat._mcmc_status, msg = 'Expect True if successfully run')
         
         check_these = ['mcmcplot', 'PI', 'chainstats']
         for ci in check_these:
             self.assertTrue(hasattr(mcstat, ci), msg = str('object has attribute: {}'.format(ci)))
-            
+        
     def test_run_simulation_with_json(self):
         mcstat = gf.basic_mcmc()
         mcstat.simulation_options.nsimu = 100
@@ -417,6 +420,8 @@ class RunSimulation(unittest.TestCase):
         mcstat.simulation_options.nsimu = 200
         mcstat.simulation_options.save_to_bin = False
         mcstat.simulation_options.save_to_txt = False
+        tmpfolder = gf.generate_temp_folder()
+        mcstat.simulation_options.savedir = tmpfolder
         mcstat.simulation_options.verbosity = 20
         mcstat.run_simulation()
         self.assertTrue(mcstat._mcmc_status, msg = 'Expect True if successfully run')


### PR DESCRIPTION
Added method for adding custom samplers to MCMC.  This is still not as flexible as PyMC, but it at least provides the user with the opportunity to add Gibbs samplers to certain variables.  Future work will focus on adding options for hyperparameters and alternative likelihood functions.