### PR TITLE
Fix cp folders

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 v1.7.0 ()
 ----------------------
 - Added custom sampler feature.  Interface requires creation of a class, but allows for inclusion of things like Gibbs samplers.
+- Added check routines for reading in parallel MCMC results to ensure only directories with name 'chain_' are queried
 
 v1.6.0 (August 31, 2018)
 ----------------------

--- a/pymcmcstat/chain/ChainProcessing.py
+++ b/pymcmcstat/chain/ChainProcessing.py
@@ -131,12 +131,32 @@ def read_in_parallel_json_results_files(parallel_dir):
     '''
     # find folders in parallel_dir with name 'chain_#'
     chainfolders = os.listdir(parallel_dir)
+    chainfolders = check_parallel_directory_contents(parallel_dir, chainfolders)
     parallel_results = []
     for folder in chainfolders:
         filename = os.path.join(parallel_dir, folder, str('{}.json'.format(folder)))
         parallel_results.append(load_json_object(filename = filename))
         
     return parallel_results
+
+def check_parallel_directory_contents(parallel_dir, cf_orig):
+    '''
+    Check that items in directory are subdirectories with name "chain_#"
+    
+    Args:
+        * **parallel_dir** (:py:class:`str`): Directory where parallel log files are saved.
+        * **cf_orig** (:py:class:`list`): List of items contained in parallel directory.
+        
+    Returns:
+        * **chainfolders** (:py:class:`list`): List of items that match criteria in parallel directory.
+    '''
+    chainfolders = []
+    for cf in cf_orig:
+        if (os.path.isdir(parallel_dir + os.sep + cf) is True) and ('chain_' in cf):
+            chainfolders.append(cf)
+    
+    chainfolders.sort() # sort elements
+    return chainfolders
     
 def read_in_bin_file(filename):
     '''

--- a/pymcmcstat/chain/ChainProcessing.py
+++ b/pymcmcstat/chain/ChainProcessing.py
@@ -114,6 +114,7 @@ def read_in_parallel_savedir_files(parallel_dir, extension = 'h5', chainfile = '
     '''
     # find folders in parallel_dir with name 'chain_#'
     chainfolders = os.listdir(parallel_dir)
+    chainfolders = check_parallel_directory_contents(parallel_dir, chainfolders)
     out = []
     for folder in chainfolders:
         # create full path names with extension

--- a/test/chain/test_ChainProcessing.py
+++ b/test/chain/test_ChainProcessing.py
@@ -263,3 +263,24 @@ class GenerateChainList(unittest.TestCase):
         self.assertEqual(len(chains), 2, msg = 'expect length of 2')
         self.assertTrue(np.array_equal(chains[0], pres[0]['chain']))
         self.assertTrue(np.array_equal(chains[1], pres[1]['chain']))
+# -------------------------
+class CheckParallelDirectoryContents(unittest.TestCase):
+    def test_id_chain_no(self):
+        parallel_dir = gf.generate_temp_folder()
+        setup_problem(parallel_dir, case = 'binary')
+        chainfolders = os.listdir(parallel_dir)        
+        chainfolders2 = CP.check_parallel_directory_contents(parallel_dir, chainfolders)
+        self.assertEqual(chainfolders2, ['chain_0', 'chain_1', 'chain_2'], msg = 'List of strings do not match ({}): {} neq {}'.format(parallel_dir, chainfolders2, ['chain_0', 'chain_1', 'chain_2']))
+        shutil.rmtree(parallel_dir)
+        
+    def test_id_chain_no_with_bad_items(self):
+        parallel_dir = gf.generate_temp_folder()
+        setup_problem(parallel_dir, case = 'binary')
+        tmpfile = gf.generate_temp_file()
+        os.mkdir(parallel_dir + os.sep + 'chain')
+        if not os.path.exists(parallel_dir + os.sep + tmpfile):
+            with open(parallel_dir + os.sep + tmpfile, 'w'): pass
+        chainfolders = os.listdir(parallel_dir)        
+        chainfolders2 = CP.check_parallel_directory_contents(parallel_dir, chainfolders)
+        self.assertEqual(chainfolders2, ['chain_0', 'chain_1', 'chain_2'], msg = 'List of strings do not match ({}): {} neq {}'.format(parallel_dir, chainfolders2, ['chain_0', 'chain_1', 'chain_2']))
+        shutil.rmtree(parallel_dir)


### PR DESCRIPTION
Updated chain processing to check contents of parallel directory.  When loading results from a parallel MCMC run, it should check for directories with names that include "chain_".