### PR TITLE
removed ref to accepted attributed

### DIFF
--- a/pymcmcstat/MCMC.py
+++ b/pymcmcstat/MCMC.py
@@ -295,6 +295,7 @@ class MCMC:
                         sosobj = self.__sos_object, priorobj = self.__prior_object)
 
             # UPDATE CHAIN & SUM-OF-SQUARES CHAIN
+            self.simulation_options.accepted = accept
             self.__update_chain(accept = accept, new_set = new_set, outsidebounds = outbound)
             self.__sschain[self.__chain_index,:] = self.__old_set.ss
 

--- a/pymcmcstat/settings/SimulationOptions.py
+++ b/pymcmcstat/settings/SimulationOptions.py
@@ -78,7 +78,7 @@ class SimulationOptions:
             * **results_filename** (:py:class:`str`): Output file name when saving results structure with json.
             * **save_to_json** (:py:class:`bool`): Save results structure to json file.  Default is False.
             * **json_restart_file** (:py:class:`str`): Extract parameter covariance and last sample value from saved json file.
-
+            
         .. note::
 
             For the log file names :code:`chainfile, sschainfile, s2chainfile` and :code:`covchainfile` do not include the extension.


### PR DESCRIPTION
Added attribute to simulation options to tracks whether acceptance occurred during the last iteration.  This is useful for custom samplers that need to reference the main sampler.