### PR TITLE
Output original covariance matrix

### DIFF
--- a/pymcmcstat/procedures/CovarianceProcedures.py
+++ b/pymcmcstat/procedures/CovarianceProcedures.py
@@ -134,6 +134,7 @@ class CovarianceProcedures:
             qcov = np.diagflat(qcov)  # create covariance matrix
 
         self._qcov = np.atleast_2d(qcov[:])
+        self._qcov_original = self._qcov.copy()
 
     def __check_adascale(self, adascale, npar):
         # check adascale

--- a/pymcmcstat/samplers/Adaptation.py
+++ b/pymcmcstat/samplers/Adaptation.py
@@ -68,7 +68,7 @@ class Adaptation:
             RDR = None
             invR = None
         else:
-            message(verbosity, 2, str('i:{} adapting ({}, {}, {})'.format(
+            message(verbosity, 3, str('i:{} adapting ({}, {}, {})'.format(
                     isimu, rejected['total']*(isimu**(-1))*100, rejected['in_adaptation_interval']*(iiadapt**(-1))*100,
                     rejected['outside_bounds']*(isimu**(-1))*100)))
             # UPDATE COVARIANCE MATRIX - CHOLESKY, MEAN, SUM

--- a/pymcmcstat/structures/ResultsStructure.py
+++ b/pymcmcstat/structures/ResultsStructure.py
@@ -145,6 +145,7 @@ class ResultsStructure:
         self.results['simutime'] = simutime
         covariance._qcovorig[np.ix_(parameters._parind, parameters._parind)] = self.results['qcov']
         self.results['qcovorig'] = covariance._qcovorig
+        self.results['original_covariance'] = covariance._qcov_original
         self.basic = True  # add_basic has been execute
 
     def add_updatesigma(self, updatesigma, sigma2, S20, N0):

--- a/test/procedures/test_CovarianceProcedures.py
+++ b/test/procedures/test_CovarianceProcedures.py
@@ -11,12 +11,33 @@ import unittest
 import numpy as np
 import test.general_functions as gf
 
+
 # --------------------------
 class InitializeCP(unittest.TestCase):
 
     def test_init_CP(self):
         CP = CovarianceProcedures()
         self.assertTrue(hasattr(CP, 'description'))
+
+    def test_init_CP_original_cov(self):
+        CP = CovarianceProcedures()
+        __, options, parameters, __ = gf.setup_mcmc()
+        CP = CovarianceProcedures()
+        CP._initialize_covariance_settings(parameters = parameters, options = options)
+        self.assertTrue(hasattr(CP, '_qcov_original'), msg='Has assigned original covariance matrix')
+        original_covariance = CP._qcov_original.copy()
+        check = {
+            'R': np.random.random_sample(size = (2,2)),
+            'covchain': np.random.random_sample(size = (2,2)),
+            'meanchain': np.random.random_sample(size = (1,2)),
+            'wsum': np.random.random_sample(size = (2,1)),
+            'last_index_since_adaptation': 0,
+            'iiadapt': 100
+            }
+        CP._update_covariance_from_adaptation(**check)
+        self.assertTrue(np.array_equal(CP._qcov_original, original_covariance),
+                        msg='Expect original cov. mtx. unchanged after update.')
+
 
 # --------------------------
 class UpdateCovarianceFromAdaptation(unittest.TestCase):
@@ -25,7 +46,6 @@ class UpdateCovarianceFromAdaptation(unittest.TestCase):
         __, options, parameters, __ = gf.setup_mcmc()
         CP = CovarianceProcedures()
         CP._initialize_covariance_settings(parameters = parameters, options = options)
-        
         check = {
         'R': np.random.random_sample(size = (2,2)),
         'covchain': np.random.random_sample(size = (2,2)),
@@ -34,7 +54,6 @@ class UpdateCovarianceFromAdaptation(unittest.TestCase):
         'last_index_since_adaptation': 0,
         'iiadapt': 100
         }
-        
         CP._update_covariance_from_adaptation(**check)
         CPD = CP.__dict__
         items = ['last_index_since_adaptation', 'iiadapt']


### PR DESCRIPTION
Original covariance matrix is now included in results structure for easy reference with respect to final adapted version.  Note, the covariance matrix will include the values initialized for all parameters, not just the ones being sampled.

- Minor change to adaptation display feature to give the user more flexibility with regard to verbosity.