### PR TITLE
Added feature to display basic definitions of items in chainstats output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ v1.8.0 ()
 ----------------------
 - Added acceptance rate display feature when calling chain statistics
 - User can specify `skip` or `maxpoints` in pairwise correlation and chain panel plots in order to thin chain.
+- User can request item definitions when callings `chainstats`.
 
 v1.7.0 (April 5, 2019)
 ----------------------

--- a/pymcmcstat/chain/ChainStatistics.py
+++ b/pymcmcstat/chain/ChainStatistics.py
@@ -480,6 +480,7 @@ def get_parameter_names(nparam, results):
         names = extend_names_to_match_nparam(names, nparam)
     return names
 
+
 def _display_stat_defs():
     print('Definition for items displayed:')
     print('"mean": Average value of parameter chains.')

--- a/pymcmcstat/chain/ChainStatistics.py
+++ b/pymcmcstat/chain/ChainStatistics.py
@@ -18,7 +18,7 @@ from .ChainProcessing import generate_chain_list
 
 
 # display chain statistics
-def chainstats(chain=None, results=None, returnstats=False):
+def chainstats(chain=None, results=None, returnstats=False, display_details=False):
     '''
     Calculate chain statistics.
 
@@ -53,6 +53,9 @@ def chainstats(chain=None, results=None, returnstats=False):
         tau, m = integrated_autocorrelation_time(chain)
         # print statistics
         print_chain_statistics(names, meanii, stdii, mcerr, tau, p)
+        if display_details is True:
+            _display_stat_defs()
+        print(30*'=')
         # print acceptance rate
         print_chain_acceptance_info(chain, results=results)
         # assign stats to dictionary
@@ -476,3 +479,12 @@ def get_parameter_names(nparam, results):
         names = results['names']
         names = extend_names_to_match_nparam(names, nparam)
     return names
+
+def _display_stat_defs():
+    print('Definition for items displayed:')
+    print('"mean": Average value of parameter chains.')
+    print('"std": Standard deviation of parameter chains.')
+    print('"MC_err": Normalized batch mean standard deviation.')
+    print('"tau": Integrated autocorrelation time.')
+    print('"geweke": Geweke\'s convergence diagnostic.')
+    print(30*'-')

--- a/test/chain/test_ChainStatistics.py
+++ b/test/chain/test_ChainStatistics.py
@@ -24,7 +24,7 @@ class Chainstats_Eval(unittest.TestCase):
 
     def test_cs_eval_with_return(self):
         stats = CS.chainstats(chain=chain, returnstats=True)
-        self.assertTrue(isinstance(stats,dict))
+        self.assertTrue(isinstance(stats, dict))
 
     def test_cs_eval_with_no_return(self):
         stats = CS.chainstats(chain=chain, returnstats=False)
@@ -33,6 +33,28 @@ class Chainstats_Eval(unittest.TestCase):
     def test_cs_eval_with_no_chain(self):
         stats = CS.chainstats(chain=None, returnstats=True)
         self.assertTrue(isinstance(stats, str))
+
+    def test_string_display(self):
+        capturedOutput = io.StringIO()                  # Create StringIO object
+        sys.stdout = capturedOutput                     #  and redirect stdout.
+        CS.chainstats(chain)
+        sys.stdout = sys.__stdout__  # Reset redirect.
+        self.assertTrue(isinstance(capturedOutput.getvalue(), str),
+                        msg='Caputured string')
+        self.assertFalse('Results dictionary' in capturedOutput.getvalue(),
+                        msg='Expect results dictionary not included')
+        self.assertFalse('Definition for items displayed:' in capturedOutput.getvalue())
+
+    def test_string_display_w_details(self):
+        capturedOutput = io.StringIO()                  # Create StringIO object
+        sys.stdout = capturedOutput                     #  and redirect stdout.
+        CS.chainstats(chain, display_details=True)
+        sys.stdout = sys.__stdout__  # Reset redirect.
+        self.assertTrue(isinstance(capturedOutput.getvalue(), str),
+                        msg='Caputured string')
+        self.assertFalse('Results dictionary' in capturedOutput.getvalue(),
+                        msg='Expect results dictionary not included')
+        self.assertTrue('Definition for items displayed:' in capturedOutput.getvalue())
 
 
 # --------------------------


### PR DESCRIPTION
- Simply specify kwarg `display_details=True` when calling `chainstats`.