### PR TITLE
Improved methods for saving results

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ v1.8.0 ()
 - User can request item definitions when calling `chainstats`.
 - Resolved #51 by adding method to check if limits are incompatible.  User is provided with more descriptive error message.
 - Updated documentation for Bayesian components.
+- Added saving routines to accomodate post-processing.  A lighter version of the results dictionary is saved to json when log routines are used for chains.  This should address #55.
 
 v1.7.0 (April 5, 2019)
 ----------------------

--- a/pymcmcstat/MCMC.py
+++ b/pymcmcstat/MCMC.py
@@ -113,8 +113,14 @@ class MCMC:
         # Generate Results
         self.__generate_simulation_results()
         if self.simulation_options.save_to_json is True:
-            if self.simulation_results.basic is True:  # check that results structure has been created
-                self.simulation_results.export_simulation_results_to_json_file(results=self.simulation_results.results)
+            # check that results structure has been created
+            if self.simulation_results.basic is True:
+                if self.simulation_options.save_lightly is True:
+                    self.simulation_results.export_lightly(
+                            results=self.simulation_results.results)
+                else:                       
+                    self.simulation_results.export_simulation_results_to_json_file(
+                            results=self.simulation_results.results)
         self.mcmcplot = MCMCPlotting.Plot()
         self.PI = PredictionIntervals()
         self.chainstats = ChainStatistics.chainstats

--- a/pymcmcstat/MCMC.py
+++ b/pymcmcstat/MCMC.py
@@ -118,7 +118,7 @@ class MCMC:
                 if self.simulation_options.save_lightly is True:
                     self.simulation_results.export_lightly(
                             results=self.simulation_results.results)
-                else:                       
+                else:
                     self.simulation_results.export_simulation_results_to_json_file(
                             results=self.simulation_results.results)
         self.mcmcplot = MCMCPlotting.Plot()

--- a/pymcmcstat/ParallelMCMC.py
+++ b/pymcmcstat/ParallelMCMC.py
@@ -372,7 +372,10 @@ def assign_number_of_cores(num_cores=1):
 
 
 # -------------------------
-def load_parallel_simulation_results(savedir):
+def load_parallel_simulation_results(
+        savedir, extension='h5', chainfile='chainfile',
+        sschainfile='sschainfile', s2chainfile='s2chainfile',
+        covchainfile='covchainfile'):
     '''
     Load results from parallel simulation directory json files.
 
@@ -389,6 +392,19 @@ def load_parallel_simulation_results(savedir):
         for key in pr.keys():
             if isinstance(pres[ii][key], list):
                 pres[ii][key] = np.array(pres[ii][key])
+    # check whether chains included in json file
+    if 'chain' not in pr.keys():
+        out = CP.read_in_parallel_savedir_files(
+                savedir, extension=extension, chainfile=chainfile,
+                sschainfile=sschainfile, s2chainfile=s2chainfile,
+                covchainfile=covchainfile)
+        if out[0]['chain'] == []:
+            print('WARNING: NO CHAINS FOUND IN SAVED RESULTS\n')
+    for ii, pr in enumerate(pres):
+        pr['chain'] = out[ii]['chain']
+        pr['sschain'] = out[ii]['sschain']
+        pr['s2chain'] = out[ii]['s2chain']
+        pr['covchain'] = out[ii]['covchain']
     return pres
 
 

--- a/pymcmcstat/ParallelMCMC.py
+++ b/pymcmcstat/ParallelMCMC.py
@@ -16,6 +16,7 @@ import sys
 import os
 import copy
 import time
+import warnings
 
 
 class ParallelMCMC:
@@ -399,7 +400,7 @@ def load_parallel_simulation_results(
                 sschainfile=sschainfile, s2chainfile=s2chainfile,
                 covchainfile=covchainfile)
         if out[0]['chain'] == []:
-            print('WARNING: NO CHAINS FOUND IN SAVED RESULTS\n')
+            warnings.warn('WARNING: No chains found in saved results.', UserWarning)
     for ii, pr in enumerate(pres):
         pr['chain'] = out[ii]['chain']
         pr['sschain'] = out[ii]['sschain']

--- a/pymcmcstat/chain/ChainProcessing.py
+++ b/pymcmcstat/chain/ChainProcessing.py
@@ -162,7 +162,7 @@ def check_parallel_directory_contents(parallel_dir, cf_orig):
 
     chainfolders.sort()  # sort elements
     return chainfolders
-
+    
 
 def read_in_bin_file(filename):
     '''

--- a/pymcmcstat/chain/ChainProcessing.py
+++ b/pymcmcstat/chain/ChainProcessing.py
@@ -162,7 +162,7 @@ def check_parallel_directory_contents(parallel_dir, cf_orig):
 
     chainfolders.sort()  # sort elements
     return chainfolders
-    
+
 
 def read_in_bin_file(filename):
     '''

--- a/pymcmcstat/settings/SimulationOptions.py
+++ b/pymcmcstat/settings/SimulationOptions.py
@@ -36,7 +36,7 @@ class SimulationOptions:
                                   alphatarget=0.234, etaparam=0.7, initqcovn=None,
                                   doram=None, rndseq=None, results_filename=None,
                                   save_to_json=False, save_to_txt=False,
-                                  json_restart_file=None):
+                                  json_restart_file=None, save_lightly=False):
         '''
         Define simulation options.
 
@@ -84,6 +84,8 @@ class SimulationOptions:
             * **save_to_json** (:py:class:`bool`): Save results structure to json file.  Default is False.
             * **json_restart_file** (:py:class:`str`): Extract parameter covariance and last sample\
             value from saved json file.
+            * **save_lightly** (:py:class:`bool`): Flag to indicate whether
+              results json file should include chains.
 
         .. note::
 
@@ -163,6 +165,7 @@ class SimulationOptions:
         self.results_filename = results_filename
         self.save_to_json = save_to_json
         self.json_restart_file = json_restart_file
+        self.save_lightly = save_lightly
         self.__options_set = True  # options have been defined
 
     def _check_dependent_simulation_options(self, model):

--- a/pymcmcstat/settings/SimulationOptions.py
+++ b/pymcmcstat/settings/SimulationOptions.py
@@ -165,7 +165,8 @@ class SimulationOptions:
         self.results_filename = results_filename
         self.save_to_json = save_to_json
         self.json_restart_file = json_restart_file
-        self.save_lightly = save_lightly
+        self.save_lightly = check_lightly_save(save_lightly, save_to_json,
+                                               save_to_bin, save_to_txt)
         self.__options_set = True  # options have been defined
 
     def _check_dependent_simulation_options(self, model):
@@ -213,3 +214,26 @@ class SimulationOptions:
         for ptii in print_these:
             print('\t{} = {}'.format(ptii, getattr(self, ptii)))
         return print_these
+
+
+def check_lightly_save(save_lightly, save_to_json, save_to_bin, save_to_txt):
+    '''
+    Check settings for lightly save
+
+    If saving to json, you can specify whether or not to include the chains.
+    This is memory intensive, so it is recommended that user's take advantage
+    of the save_to_bin (binary) option when it comes to chains.  This routine
+    will save everything to json is save_to_bin and save_to_txt are both set
+    to False for the chains.
+
+    Args:
+        * **save_lightly** (:py:class:`bool`): Flag to save results w/out arrays
+        * **save_to_json** (:py:class:`bool`): Flag to save to json
+        * **save_to_bin** (:py:class:`bool`): Flag to save to binary
+        * **save_to_txt** (:py:class:`bool`): Flag to save to text
+    '''
+    if save_to_json is True:
+        if save_to_bin is False and save_to_txt is False:
+            return False
+        else:
+            return save_lightly

--- a/pymcmcstat/settings/SimulationOptions.py
+++ b/pymcmcstat/settings/SimulationOptions.py
@@ -223,8 +223,9 @@ def check_lightly_save(save_lightly, save_to_json, save_to_bin, save_to_txt):
     If saving to json, you can specify whether or not to include the chains.
     This is memory intensive, so it is recommended that user's take advantage
     of the save_to_bin (binary) option when it comes to chains.  This routine
-    will save everything to json is save_to_bin and save_to_txt are both set
-    to False for the chains.
+    will save everything to json unless the chains are already being saved
+    via one of the logging methods.  If yes, save_lightly is set to True to
+    avoid duplicate chains being saved to the hard disc.
 
     Args:
         * **save_lightly** (:py:class:`bool`): Flag to save results w/out arrays
@@ -233,7 +234,9 @@ def check_lightly_save(save_lightly, save_to_json, save_to_bin, save_to_txt):
         * **save_to_txt** (:py:class:`bool`): Flag to save to text
     '''
     if save_to_json is True:
-        if save_to_bin is False and save_to_txt is False:
-            return False
+        if save_to_bin is True or save_to_txt is True:
+            return True
         else:
             return save_lightly
+    else:
+        return save_lightly

--- a/pymcmcstat/settings/SimulationOptions.py
+++ b/pymcmcstat/settings/SimulationOptions.py
@@ -220,12 +220,9 @@ def check_lightly_save(save_lightly, save_to_json, save_to_bin, save_to_txt):
     '''
     Check settings for lightly save
 
-    If saving to json, you can specify whether or not to include the chains.
-    This is memory intensive, so it is recommended that user's take advantage
-    of the save_to_bin (binary) option when it comes to chains.  This routine
-    will save everything to json unless the chains are already being saved
-    via one of the logging methods.  If yes, save_lightly is set to True to
-    avoid duplicate chains being saved to the hard disc.
+    If saving to json, chains will be removed if already being stored via
+    one of the logging methods, binary or text.  If logging methods not
+    being used, then chains will be included in json file.
 
     Args:
         * **save_lightly** (:py:class:`bool`): Flag to save results w/out arrays
@@ -237,6 +234,6 @@ def check_lightly_save(save_lightly, save_to_json, save_to_bin, save_to_txt):
         if save_to_bin is True or save_to_txt is True:
             return True
         else:
-            return save_lightly
+            return False
     else:
         return save_lightly

--- a/pymcmcstat/structures/ResultsStructure.py
+++ b/pymcmcstat/structures/ResultsStructure.py
@@ -55,6 +55,28 @@ class ResultsStructure:
         file = _create_path_without_extension(savedir, filename)
         self.save_json_object(results, file)
 
+    # --------------------------------------------------------
+    def export_lightly(self, results):
+        '''
+        Export minimal simulation results to a json file.
+
+        This will save the key terms in the results dict, excluding arrays.
+        Ideally, this is used in conjunction with one of the chain saving
+        methods.  The goal is to provide a results dict to simplify post-
+        processing and reduces storage overhead.
+
+        Args:
+            * **results** (:class:`~.ResultsStructure`): Dictionary of MCMC simulation results/settings.
+        '''
+        savedir = results['simulation_options']['savedir']
+        filename = self.determine_filename(options=results['simulation_options'])
+        _check_directory(savedir)  # make sure output directory exists
+        file = _create_path_without_extension(savedir, filename)
+        light_results = results.copy()
+        # remove arrays from light results
+        light_results = lighten_results(results=light_results)
+        self.save_json_object(light_results, file)
+
     @classmethod
     def determine_filename(cls, options):
         '''
@@ -313,3 +335,17 @@ class ResultsStructure:
             This feature is not currently implemented.
         '''
         self.results['rndseq'] = rndseq
+
+
+def lighten_results(results):
+    '''
+    Saves subset of features of the simulation options in a nested dictionary.
+
+    Args:
+        * **options** (:class:`.SimulationOptions`): MCMC simulation options.
+    '''
+    # define list of keywords to NOT add to results structure
+    do_not_save_these_keys = ['chain', 's2chain', 'sschain']
+    for keyii in do_not_save_these_keys:
+        results = removekey(results, keyii)
+    return results

--- a/test/chain/test_ChainProcessing.py
+++ b/test/chain/test_ChainProcessing.py
@@ -357,8 +357,16 @@ class LoadSerialSimulationResults(unittest.TestCase):
         RS = ResultsStructure()
         RS.save_json_object(results, tmpfile0)
         pres = CP.load_serial_simulation_results(tmpfolder0)
-        print(pres)
         shutil.rmtree(tmpfolder)
         self.assertTrue(isinstance(pres['a'], np.ndarray))
         self.assertTrue(isinstance(pres['b'], str))
         self.assertEqual(pres['b'], 'hello')
+
+    def test_load_ser_sim_res_no_json(self):
+        tmpfolder = gf.generate_temp_folder()
+        os.makedirs(tmpfolder)
+        pres = CP.load_serial_simulation_results(tmpfolder)
+        shutil.rmtree(tmpfolder)
+        self.assertTrue(isinstance(pres['chain'], list))
+        self.assertTrue(isinstance(pres['s2chain'], list))
+        self.assertEqual(pres['chain'], [])

--- a/test/chain/test_ChainProcessing.py
+++ b/test/chain/test_ChainProcessing.py
@@ -7,6 +7,7 @@ Created on Thu Jun 21 10:10:43 2018
 """
 
 from pymcmcstat.chain import ChainProcessing as CP
+from pymcmcstat.structures.ResultsStructure import ResultsStructure
 import test.general_functions as gf
 import unittest
 from mock import patch
@@ -15,6 +16,7 @@ import os
 import shutil
 import io
 import sys
+
 
 # --------------------------
 class CreatePathWithExtensionforAllLogs(unittest.TestCase):
@@ -39,6 +41,7 @@ class CreatePathWithExtensionforAllLogs(unittest.TestCase):
 
 # --------------------------
 class CreatePathWithExtension(unittest.TestCase):
+
     def test_cpwe_basic_h5(self):
         file = CP._create_path_with_extension(savedir = 'test', file = 'file', extension = 'h5')
         self.assertEqual(file, 'test/file.h5', msg = 'Expect matching string')
@@ -49,12 +52,14 @@ class CreatePathWithExtension(unittest.TestCase):
         
 # --------------------------
 class CreatePathWithOutExtension(unittest.TestCase):
+
     def test_cpwe_basic(self):
         file = CP._create_path_without_extension(savedir = 'test', file = 'file')
         self.assertEqual(file, 'test/file', msg = 'Expect matching string')
 
 # --------------------------
 class ReadInBinFile(unittest.TestCase):
+
     def test_readinbinaryfile_warning(self):
         out = CP.read_in_bin_file(filename = 'abcdedf0123')
         self.assertEqual(out, [], msg = 'expect empty list')
@@ -69,6 +74,7 @@ class ReadInBinFile(unittest.TestCase):
         
 # --------------------------
 class ReadInTextFile(unittest.TestCase):
+
     def test_readintextfile_warning(self):
         out = CP.read_in_txt_file(filename = 'abcdedf0123')
         self.assertEqual(out, [], msg = 'expect empty list')
@@ -80,6 +86,7 @@ class ReadInTextFile(unittest.TestCase):
 
 # -------------------
 class CheckDirectory(unittest.TestCase):
+
     def test_check_directory(self):
         tmpfolder = gf.generate_temp_folder()
         CP._check_directory(tmpfolder)
@@ -88,6 +95,7 @@ class CheckDirectory(unittest.TestCase):
         
 # -------------------
 class CheckSaveToTextFile(unittest.TestCase):
+
     def test_save_to_text_file(self):
         tmpfile = gf.generate_temp_file(extension = 'txt')
         CP._save_to_txt_file(filename = tmpfile, mtx = np.array([0.1, 0.2]))
@@ -98,6 +106,7 @@ class CheckSaveToTextFile(unittest.TestCase):
         
 # -------------------
 class CheckSaveToBinaryFile(unittest.TestCase):
+
     def test_save_to_binary_file(self):
         tmpfile = gf.generate_temp_file(extension = 'h5')
         CP._save_to_bin_file(filename = tmpfile, datasetname = 'd1', mtx = np.array([0.1, 0.2]))
@@ -106,6 +115,7 @@ class CheckSaveToBinaryFile(unittest.TestCase):
         
 # -------------------
 class AddToLog(unittest.TestCase):
+
     def test_add_to_log(self):
         tmpfile = gf.generate_temp_file(extension = 'txt')
         CP._add_to_log(filename = tmpfile, logstr = 'hello world')
@@ -114,16 +124,21 @@ class AddToLog(unittest.TestCase):
             loadstr = file.read()
         self.assertEqual(loadstr, 'hello world', msg = 'Message should match')
         os.remove(tmpfile)
+
+
 # -------------------
 class StandardCheck(unittest.TestCase):
+
     def __init__(self, out, mcstat):
         self.assertTrue(np.array_equal(out['chain'], mcstat._MCMC__chain), msg = str('Expect arrays to match: chain'))
         self.assertTrue(np.array_equal(out['sschain'], mcstat._MCMC__sschain), msg = str('Expect arrays to match: sschain'))
         self.assertTrue(np.array_equal(out['s2chain'], mcstat._MCMC__s2chain), msg = str('Expect arrays to match: s2chain'))
         self.assertTrue(np.array_equal(out['covchain'], np.dot(mcstat._covariance._R.transpose(),mcstat._covariance._R)), msg = str('Expect arrays to match: chain'))
 
+
 # -------------------
 class ReadInSavedirFiles(unittest.TestCase):
+
     def test_read_in_savedir_files_h5(self):
         mcstat = gf.setup_case()
         savedir = gf.generate_temp_folder()
@@ -166,7 +181,7 @@ def setup_problem(parallel_dir, case = 'binary'):
     for ii in range(3):
         chain_dir = str('chain_{}'.format(ii))
         mcstat.simulation_options.savedir = str('{}{}{}'.format(parallel_dir,os.sep,chain_dir))
-        if case is 'binary':
+        if case == 'binary':
             mcstat.simulation_options.save_to_bin = True
             mcstat.simulation_options.save_to_txt = False
             mcstat._MCMC__save_to_log_file(chains = mcstat._MCMC__chains, start = 0, end = 100)
@@ -177,7 +192,10 @@ def setup_problem(parallel_dir, case = 'binary'):
             mcstat._MCMC__save_to_log_file(chains = mcstat._MCMC__chains, start = 0, end = 100)
             mcstat._MCMC__save_to_log_file(chains = [dict(mtx = np.dot(mcstat._covariance._R.transpose(),mcstat._covariance._R))], start = 0, end = 100, covmtx = True)
     return mcstat
+
+
 class ReadInParallelSavedirFiles(unittest.TestCase):
+
     def test_read_in_parallel_bin(self):
         parallel_dir = gf.generate_temp_folder()
         mcstat = setup_problem(parallel_dir, case = 'binary')
@@ -205,8 +223,11 @@ class ReadInParallelSavedirFiles(unittest.TestCase):
         self.assertEqual(out[1], None)
         self.assertEqual(out[2], None)
         shutil.rmtree(parallel_dir)
+
+
 # -------------------
 class PrintLogFiles(unittest.TestCase):
+
     def test_print_log_files(self):
         mcstat = gf.setup_case()
         savedir = gf.generate_temp_folder()
@@ -225,6 +246,8 @@ class PrintLogFiles(unittest.TestCase):
         self.assertTrue(isinstance(capturedOutput.getvalue(), str), msg = 'Should contain a string')
         self.assertTrue('Display log file:' in capturedOutput.getvalue(), msg = 'Expect string to contain these words')
         shutil.rmtree(savedir)
+
+
 # -------------------------
 def setup_pres():
     pres = []
@@ -232,7 +255,9 @@ def setup_pres():
     pres.append(dict(chain = np.array(np.random.random_sample(size = (100,3))), nsimu = 100))
     return pres
 
+
 class GenerateCombinedChainWithIndex(unittest.TestCase):
+
     def test_generate_combined_chain(self):
         pres = setup_pres()
         combined_chain, index = CP.generate_combined_chain_with_index(pres = pres)
@@ -248,8 +273,11 @@ class GenerateCombinedChainWithIndex(unittest.TestCase):
         self.assertEqual(len(index), 200, msg = 'index should have length 100')
         self.assertTrue(np.array_equal(combined_chain[0:100,:], pres[0]['chain']))
         self.assertTrue(np.array_equal(combined_chain[100:,:], pres[1]['chain']))
+
+
 # -------------------------
 class GenerateChainList(unittest.TestCase):
+
     def test_generate_chain_list(self):
         pres = setup_pres()
         chains = CP.generate_chain_list(pres = pres)
@@ -263,8 +291,11 @@ class GenerateChainList(unittest.TestCase):
         self.assertEqual(len(chains), 2, msg = 'expect length of 2')
         self.assertTrue(np.array_equal(chains[0], pres[0]['chain']))
         self.assertTrue(np.array_equal(chains[1], pres[1]['chain']))
+
+
 # -------------------------
 class CheckParallelDirectoryContents(unittest.TestCase):
+
     def test_id_chain_no(self):
         parallel_dir = gf.generate_temp_folder()
         setup_problem(parallel_dir, case = 'binary')
@@ -284,3 +315,50 @@ class CheckParallelDirectoryContents(unittest.TestCase):
         chainfolders2 = CP.check_parallel_directory_contents(parallel_dir, chainfolders)
         self.assertEqual(chainfolders2, ['chain_0', 'chain_1', 'chain_2'], msg = 'List of strings do not match ({}): {} neq {}'.format(parallel_dir, chainfolders2, ['chain_0', 'chain_1', 'chain_2']))
         shutil.rmtree(parallel_dir)
+
+
+# -------------------------
+class LoadParallelSimulationResults(unittest.TestCase):
+
+    def test_load_par_sim_res(self):
+        tmpfolder = gf.generate_temp_folder()
+        tmpfolder0 = os.path.join(tmpfolder, 'chain_0')
+        os.makedirs(tmpfolder0)
+        tmpfolder1 = os.path.join(tmpfolder, 'chain_1')
+        os.makedirs(tmpfolder1)
+        tmpfile0 = 'chain_0.json'
+        tmpfile0 = os.path.join(tmpfolder0, tmpfile0)
+        tmpfile1 = 'chain_1.json'
+        tmpfile1 = os.path.join(tmpfolder1, tmpfile1)
+        results = dict(a=[0, 1], b='hello')
+        RS = ResultsStructure()
+        RS.save_json_object(results, tmpfile0)
+        RS.save_json_object(results, tmpfile1)
+        pres = CP.load_parallel_simulation_results(tmpfolder)
+        shutil.rmtree(tmpfolder)
+        self.assertTrue(isinstance(pres[0]['a'], np.ndarray))
+        self.assertTrue(isinstance(pres[1]['a'], np.ndarray))
+        self.assertTrue(isinstance(pres[0]['b'], str))
+        self.assertTrue(isinstance(pres[1]['b'], str))
+        self.assertEqual(pres[0]['b'], 'hello')
+        self.assertEqual(pres[1]['b'], 'hello')
+
+
+# -------------------------
+class LoadSerialSimulationResults(unittest.TestCase):
+
+    def test_load_ser_sim_res(self):
+        tmpfolder = gf.generate_temp_folder()
+        tmpfolder0 = os.path.join(tmpfolder, 'chain_0')
+        os.makedirs(tmpfolder0)
+        tmpfile0 = 'chain_0.json'
+        tmpfile0 = os.path.join(tmpfolder0, tmpfile0)
+        results = dict(a=[0, 1], b='hello')
+        RS = ResultsStructure()
+        RS.save_json_object(results, tmpfile0)
+        pres = CP.load_serial_simulation_results(tmpfolder0)
+        print(pres)
+        shutil.rmtree(tmpfolder)
+        self.assertTrue(isinstance(pres['a'], np.ndarray))
+        self.assertTrue(isinstance(pres['b'], str))
+        self.assertEqual(pres['b'], 'hello')

--- a/test/settings/test_SimulationOptions.py
+++ b/test/settings/test_SimulationOptions.py
@@ -101,6 +101,12 @@ class CheckSaveLightly(unittest.TestCase):
         out = check_lightly_save(save_lightly=False, save_to_json=True,
                                  save_to_bin=True, save_to_txt=False)
         self.assertTrue(out, msg='Expect True when logging used')
+        out = check_lightly_save(save_lightly=False, save_to_json=True,
+                                 save_to_bin=False, save_to_txt=False)
+        self.assertFalse(out, msg='Expect False if no logging but json')
+        out = check_lightly_save(save_lightly=True, save_to_json=True,
+                                 save_to_bin=False, save_to_txt=False)
+        self.assertFalse(out, msg='Expect False if no logging but json')
 
     def test_json_false(self):
         out = check_lightly_save(save_lightly=False, save_to_json=False,
@@ -112,11 +118,3 @@ class CheckSaveLightly(unittest.TestCase):
         out = check_lightly_save(save_lightly=False, save_to_json=False,
                                  save_to_bin=True, save_to_txt=False)
         self.assertFalse(out, msg='Expect user-defined when json False')
-
-    def test_ud(self):
-        out = check_lightly_save(save_lightly=False, save_to_json=True,
-                                 save_to_bin=False, save_to_txt=False)
-        self.assertFalse(out, msg='Expect False')
-        out = check_lightly_save(save_lightly=True, save_to_json=True,
-                                 save_to_bin=False, save_to_txt=False)
-        self.assertTrue(out, msg='Expect True')

--- a/test/settings/test_SimulationOptions.py
+++ b/test/settings/test_SimulationOptions.py
@@ -7,6 +7,7 @@ Created on Thu May 31 11:52:58 2018
 """
 
 from pymcmcstat.settings.SimulationOptions import SimulationOptions
+from pymcmcstat.settings.SimulationOptions import check_lightly_save
 from pymcmcstat.settings.ModelSettings import ModelSettings
 import unittest
 
@@ -24,12 +25,12 @@ class DisplaySimulationOptions(unittest.TestCase):
     def test_print_these_none(self):
         SO = setup_options()
         print_these = SO.display_simulation_options(print_these = None)
-        self.assertEqual(print_these, ['nsimu', 'adaptint', 'ntry', 'method', 'printint', 'lastadapt', 'drscale', 'qcov'], msg = 'Default print keys')
+        self.assertEqual(print_these, ['nsimu', 'adaptint', 'ntry', 'method', 'printint', 'lastadapt', 'drscale', 'qcov'], msg='Default print keys')
         
     def test_print_these_not_none(self):
         SO = setup_options()
         print_these = SO.display_simulation_options(print_these = ['nsimu'])
-        self.assertEqual(print_these, ['nsimu'], msg = 'Specified print keys')
+        self.assertEqual(print_these, ['nsimu'], msg='Specified print keys')
         
 # --------------------------
 class CheckDependentOptions(unittest.TestCase):
@@ -37,30 +38,31 @@ class CheckDependentOptions(unittest.TestCase):
     def test_dodram(self):
         SO = setup_options(ntry = 1)
         SO._check_dependent_simulation_options(model = MS)
-        self.assertEqual(SO.dodram, 0, msg = 'DRAM turned off because ntry <= 1')
+        self.assertEqual(SO.dodram, 0, msg='DRAM turned off because ntry <= 1')
         SO = setup_options(ntry = 2)
         SO._check_dependent_simulation_options(model = MS)
-        self.assertEqual(SO.dodram, 1, msg = 'DRAM turned on because ntry > 1')
+        self.assertEqual(SO.dodram, 1, msg='DRAM turned on because ntry > 1')
         
     def test_lastadapt(self):
         SO = setup_options(lastadapt = 0)
         SO._check_dependent_simulation_options(model = MS)
-        self.assertEqual(SO.lastadapt, SO.nsimu, msg = 'lastadapt set to nsimu')
+        self.assertEqual(SO.lastadapt, SO.nsimu, msg='lastadapt set to nsimu')
         SO.define_simulation_options(lastadapt = 10)
         SO._check_dependent_simulation_options(model = MS)
-        self.assertEqual(SO.lastadapt, 10, msg = 'lastadapt unchanged')
+        self.assertEqual(SO.lastadapt, 10, msg='lastadapt unchanged')
         
     def test_printint(self):
         SO = setup_options(printint = None)
         SO._check_dependent_simulation_options(model = MS)
-        self.assertEqual(SO.printint, max(100,min(1000,SO.adaptint)), msg = 'printint was updated')
+        self.assertEqual(SO.printint, max(100,min(1000,SO.adaptint)), msg='printint was updated')
         
     def test_updatesigma(self):
         SO = setup_options(updatesigma = False)
         MS.N0 = [1.]
         SO._check_dependent_simulation_options(model = MS)
-        self.assertTrue(SO.updatesigma, msg = 'updatesigma turned on because N0 not empty')
-        
+        self.assertTrue(SO.updatesigma, msg='updatesigma turned on because N0 not empty')
+
+
 # --------------------------
 class DefineOptions(unittest.TestCase):
     
@@ -72,16 +74,49 @@ class DefineOptions(unittest.TestCase):
             
     def test_ntry_assigment(self):
         SO = setup_options(ntry = 3)
-        self.assertEqual(SO.ntry, 3, msg = 'ntry set to 3')
+        self.assertEqual(SO.ntry, 3, msg='ntry set to 3')
         
     def test_adascale_assigment(self):
         SO = setup_options(adascale = 3)
-        self.assertEqual(SO.adascale, 3, msg = 'adascale set to 3')
+        self.assertEqual(SO.adascale, 3, msg='adascale set to 3')
         
     def test_label_assigment(self):
         SO = setup_options(label = '3')
-        self.assertEqual(SO.label, '3', msg = 'label set to 3')
+        self.assertEqual(SO.label, '3', msg='label set to 3')
         
     def test_savedir_assigment(self):
         SO = setup_options(savedir = '3')
-        self.assertEqual(SO.savedir, '3', msg = 'savedir set to 3')
+        self.assertEqual(SO.savedir, '3', msg='savedir set to 3')
+
+# --------------------------
+class CheckSaveLightly(unittest.TestCase):
+
+    def test_json_true(self):
+        out = check_lightly_save(save_lightly=False, save_to_json=True,
+                                 save_to_bin=True, save_to_txt=True)
+        self.assertTrue(out, msg='Expect True when logging used')
+        out = check_lightly_save(save_lightly=False, save_to_json=True,
+                                 save_to_bin=False, save_to_txt=True)
+        self.assertTrue(out, msg='Expect True when logging used')
+        out = check_lightly_save(save_lightly=False, save_to_json=True,
+                                 save_to_bin=True, save_to_txt=False)
+        self.assertTrue(out, msg='Expect True when logging used')
+
+    def test_json_false(self):
+        out = check_lightly_save(save_lightly=False, save_to_json=False,
+                                 save_to_bin=True, save_to_txt=True)
+        self.assertFalse(out, msg='Expect user-defined when json False')
+        out = check_lightly_save(save_lightly=False, save_to_json=False,
+                                 save_to_bin=False, save_to_txt=True)
+        self.assertFalse(out, msg='Expect user-defined when json False')
+        out = check_lightly_save(save_lightly=False, save_to_json=False,
+                                 save_to_bin=True, save_to_txt=False)
+        self.assertFalse(out, msg='Expect user-defined when json False')
+
+    def test_ud(self):
+        out = check_lightly_save(save_lightly=False, save_to_json=True,
+                                 save_to_bin=False, save_to_txt=False)
+        self.assertFalse(out, msg='Expect False')
+        out = check_lightly_save(save_lightly=True, save_to_json=True,
+                                 save_to_bin=False, save_to_txt=False)
+        self.assertTrue(out, msg='Expect True')


### PR DESCRIPTION
- User can now save a lighter version of results dictionary to accommodate post-processing.
- Lighter version removes chains from results dictionary to keep json file a manageable size.
- Methods added to ChainProcessing module for loading serial and parallel MCMC simulations.  These methods load the results dictionary from json, then look to see if the chains are included.  If not, then it searches for log files matching the specified extension.  If none are found, then it returns an empty list for each type of chain.
- This should help to address #55 .  