### PR TITLE
Resolved #66 by added KDE objects to output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ v1.8.0 ()
 - Resolved #51 by adding method to check if limits are incompatible.  User is provided with more descriptive error message.
 - Updated documentation for Bayesian components.
 - Added saving routines to accomodate post-processing.  A lighter version of the results dictionary is saved to json when log routines are used for chains.  This should address #55.
+- Option to return KDE objects when using `plot_density_panel`.  User can then evaluate pdf directly.  This should address #66.
 
 v1.7.0 (April 5, 2019)
 ----------------------

--- a/pymcmcstat/plotting/MCMCPlotting.py
+++ b/pymcmcstat/plotting/MCMCPlotting.py
@@ -22,7 +22,8 @@ except ImportError as e:
 
 
 # --------------------------------------------
-def plot_density_panel(chains, names=None, hist_on=False, figsizeinches=None):
+def plot_density_panel(chains, names=None, hist_on=False, figsizeinches=None,
+                       return_kde=False):
     '''
     Plot marginal posterior densities
 
@@ -36,6 +37,7 @@ def plot_density_panel(chains, names=None, hist_on=False, figsizeinches=None):
     ns1, ns2, names, figsizeinches = setup_plot_features(
             nparam=nparam, names=names, figsizeinches=figsizeinches)
     f = plt.figure(dpi=100, figsize=(figsizeinches))  # initialize figure
+    kdehandle = []
     for ii in range(nparam):
         # define chain
         chain = chains[:, ii].reshape(nsimu, 1)  # check indexing
@@ -52,7 +54,11 @@ def plot_density_panel(chains, names=None, hist_on=False, figsizeinches=None):
         plt.xlabel(names[ii])
         plt.ylabel(str('$\\pi$({}$|M^{}$)'.format(names[ii], '{data}')))
         plt.tight_layout(rect=[0, 0.03, 1, 0.95], h_pad=1.0)  # adjust spacing
-    return f
+        kdehandle.append(kde)
+    if return_kde is True:
+        return f, kdehandle
+    else:
+        return f
 
 
 # --------------------------------------------

--- a/test/plotting/test_MCMCPlotting.py
+++ b/test/plotting/test_MCMCPlotting.py
@@ -15,10 +15,11 @@ import unittest
 
 # --------------------------
 class PlotDensityPanel(unittest.TestCase):
+
     def standard_check(self, hist_on = True):
         npar = 3
         chains = np.random.random_sample(size = (100,npar))
-        f = MP.plot_density_panel(chains = chains)
+        f = MP.plot_density_panel(chains=chains)
         for ii in range(npar):
             name = str('$p_{{{}}}$'.format(ii))
             self.assertEqual(f.axes[ii].get_xlabel(), name, msg = str('Should be {}'.format(name)))
@@ -32,6 +33,14 @@ class PlotDensityPanel(unittest.TestCase):
 
     def test_basic_plot_features_with_hist_on(self):
         self.standard_check(hist_on = True)
+
+    def test_return_kde_handles(self):
+        npar = 3
+        chains = np.random.random_sample(size=(100, npar))
+        f, kdehandle = MP.plot_density_panel(chains=chains, return_kde=True)
+        self.assertEqual(len(kdehandle), 3,
+                         msg='Expect 3 elements in list')
+
 
 # --------------------------
 class PlotChainPanel(unittest.TestCase):


### PR DESCRIPTION
- User can output kde objects by specify kwarg `return_kde=True` when using `plot_density_panel` method.