### PR TITLE
Added 'allnames' feature to results (Fixes #71)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Changelog
 
 v1.9.0 ()
 ---------
+- Added feature to results structure to store all parameters names, regardless of whether or not they are included in sampling.
+- Added mcmcplot package to requirements.  All chain diagnostic plotting now defaults to this package.
 - Added new module for uncertainty propagation.  Aims to provide more flexible API for user to plot different combinations of credible and prediction intervals.
 - Added a plotting routine so that you can plot a 2-D interval in 3-D space.
 

--- a/pymcmcstat/structures/ResultsStructure.py
+++ b/pymcmcstat/structures/ResultsStructure.py
@@ -161,6 +161,7 @@ class ResultsStructure:
         self.results['qcov_scale'] = covariance._qcov_scale
         self.results['mean'] = covariance._meanchain
         self.results['names'] = [parameters._names[ii] for ii in parameters._parind]
+        self.results['allnames'] = [name for name in parameters._names]
         self.results['limits'] = [parameters._lower_limits[parameters._parind[:]],
                                   parameters._upper_limits[parameters._parind[:]]]
         self.results['nsimu'] = nsimu

--- a/test/structures/test_ResultsStructure.py
+++ b/test/structures/test_ResultsStructure.py
@@ -75,6 +75,25 @@ class AddBasic(unittest.TestCase):
         self.assertTrue(np.array_equal(RS.results['R'], covariance._R), msg = 'Cholesky matches')
         self.assertTrue(np.array_equal(RS.results['qcov'], np.dot(covariance._R.transpose(),covariance._R)), msg = 'Covariance matches')
 
+    def test_allnames(self):
+        model, options, parameters, data, covariance, rejected, chain, s2chain, sschain = gf.setup_mcmc_case_dr()
+        RS = ResultsStructure()
+        RS.add_basic(nsimu=options.nsimu,
+                     covariance=covariance,
+                     parameters=parameters,
+                     rejected=rejected,
+                     simutime=0.001,
+                     theta=chain[-1,:])
+        allnames = RS.results['allnames']
+        names = RS.results['names']
+        print(allnames)
+        print(names)
+        self.assertEqual(len(allnames), len(names) + 1,
+                         msg='Expect extra name in allnames')
+        self.assertEqual(allnames[-1], 'b2',
+                         msg='Expect final parameter is b2')
+        
+        
 # -------------------
 class AddDRAM(unittest.TestCase):
     def test_addbasic_false(self):


### PR DESCRIPTION
- The key 'allnames' is the list of all parameter names as added to the parameter object, regardless of whether or not they are included in sampling