### PR TITLE
Closes #79 - chainstats display tolerancing

### DIFF
--- a/pymcmcstat/chain/ChainStatistics.py
+++ b/pymcmcstat/chain/ChainStatistics.py
@@ -110,7 +110,6 @@ def print_chain_statistics(names, meanii, stdii, mcerr, tau, p):
         mcerrstr = format_number_to_str(mcerr[ii])
         taustr = format_number_to_str(tau[ii])
         pstr = format_number_to_str(p[ii])
-                                        
         print('{:s}: {:s} {:s} {:s} {:s} {:s}'.format(
                 namestr, meanstr, stdstr, mcerrstr, taustr, pstr))
         # if meanii[ii] > 1e4:

--- a/pymcmcstat/chain/ChainStatistics.py
+++ b/pymcmcstat/chain/ChainStatistics.py
@@ -15,6 +15,7 @@ import scipy.stats
 from scipy.fftpack import fft
 from ..plotting.utilities import generate_default_names, extend_names_to_match_nparam
 from .ChainProcessing import generate_chain_list
+from ..utilities.general import format_number_to_str
 
 
 # display chain statistics
@@ -95,7 +96,7 @@ def print_chain_statistics(names, meanii, stdii, mcerr, tau, p):
     # print statistics
     print('\n')
     print(30*'-')
-    print('{:10s}: {:>10s} {:>10s} {:>10s} {:>10s} {:>10s}'.format(
+    print('{:>10s}: {:>9s} {:>9s} {:>9s} {:>9s} {:>9s}'.format(
             'name',
             'mean',
             'std',
@@ -103,21 +104,30 @@ def print_chain_statistics(names, meanii, stdii, mcerr, tau, p):
             'tau',
             'geweke'))
     for ii in range(npar):
-        if meanii[ii] > 1e4:
-            print('{:10s}: {:10.4g} {:10.4g} {:10.4f} {:10.4f} {:10.4f}'.format(names[ii],
-                  meanii[ii],
-                  stdii[ii],
-                  mcerr[ii],
-                  tau[ii],
-                  p[ii]))
-        else:
-            print('{:10s}: {:10.4f} {:10.4f} {:10.4f} {:10.4f} {:10.4f}'.format(
-                    names[ii],
-                    meanii[ii],
-                    stdii[ii],
-                    mcerr[ii],
-                    tau[ii],
-                    p[ii]))
+        namestr = str('{:>10s}'.format(names[ii]))
+        meanstr = format_number_to_str(meanii[ii])
+        stdstr = format_number_to_str(stdii[ii])
+        mcerrstr = format_number_to_str(mcerr[ii])
+        taustr = format_number_to_str(tau[ii])
+        pstr = format_number_to_str(p[ii])
+                                        
+        print('{:s}: {:s} {:s} {:s} {:s} {:s}'.format(
+                namestr, meanstr, stdstr, mcerrstr, taustr, pstr))
+        # if meanii[ii] > 1e4:
+        #     print('{:10s}: {:10.4g} {:10.4g} {:10.4f} {:10.4f} {:10.4f}'.format(names[ii],
+        #           meanii[ii],
+        #           stdii[ii],
+        #           mcerr[ii],
+        #           tau[ii],
+        #           p[ii]))
+        # else:
+        #     print('{:10s}: {:10.4f} {:10.4f} {:10.4f} {:10.4f} {:10.4f}'.format(
+        #             names[ii],
+        #             meanii[ii],
+        #             stdii[ii],
+        #             mcerr[ii],
+        #             tau[ii],
+        #             p[ii]))
     print(30*'-')
 
 

--- a/pymcmcstat/settings/ModelParameters.py
+++ b/pymcmcstat/settings/ModelParameters.py
@@ -9,7 +9,7 @@ Created on Wed Jan 17 09:13:03 2018
 import numpy as np
 import math
 import sys
-from ..utilities.general import message
+from ..utilities.general import message, format_number_to_str
 
 
 # --------------------------
@@ -433,23 +433,6 @@ def prior_display_setting(x):
     else:
         h2 = '^2'
     return h2
-
-
-# --------------------------
-def format_number_to_str(number):
-    '''
-    Format number for display
-
-    Args:
-        * **number** (:py:class:`float`): Number to be formatted
-
-    Returns:
-        * (:py:class:`str`): Formatted string display
-    '''
-    if abs(number) >= 1e4 or abs(number) <= 1e-2:
-        return str('{:9.2e}'.format(number))
-    else:
-        return str('{:9.2f}'.format(number))
 
 
 # --------------------------

--- a/pymcmcstat/utilities/general.py
+++ b/pymcmcstat/utilities/general.py
@@ -25,6 +25,23 @@ def message(verbosity, level, printthis):
     return printed
 
 
+# --------------------------
+def format_number_to_str(number):
+    '''
+    Format number for display
+
+    Args:
+        * **number** (:py:class:`float`): Number to be formatted
+
+    Returns:
+        * (:py:class:`str`): Formatted string display
+    '''
+    if abs(number) >= 1e4 or abs(number) <= 1e-2:
+        return str('{:9.2e}'.format(number))
+    else:
+        return str('{:9.2f}'.format(number))
+
+
 def removekey(d, key):
     '''
     Removed elements from dictionary and return the remainder.

--- a/test/settings/test_ModelParameters.py
+++ b/test/settings/test_ModelParameters.py
@@ -11,7 +11,7 @@ functions tested include:
 @author: prmiles
 """
 from pymcmcstat.settings.ModelParameters import ModelParameters
-from pymcmcstat.settings.ModelParameters import format_number_to_str, generate_default_name, check_verbosity, replace_list_elements
+from pymcmcstat.settings.ModelParameters import generate_default_name, check_verbosity, replace_list_elements
 from pymcmcstat.settings.ModelParameters import noadapt_display_setting, check_noadaptind, prior_display_setting, less_than_or_equal_to_zero
 from pymcmcstat.settings.SimulationOptions import SimulationOptions
 import unittest
@@ -178,12 +178,6 @@ class GenerateDefaultName(unittest.TestCase):
         self.assertEqual(generate_default_name(nparam = 2), '$p_{2}$', msg='0 based naming convention.')
         self.assertEqual(generate_default_name(nparam = 10), '$p_{10}$', msg='0 based naming convention.')
 
-# --------------------------
-class FormatNumberToStr(unittest.TestCase):
-    def test_format_number_to_str(self):
-        self.assertEqual(str('{:9.2f}'.format(1.0)), format_number_to_str(1.0), msg = str('Exect: {:9.2f}'.format(1.0)))
-        self.assertEqual(str('{:9.2e}'.format(1.0e4)), format_number_to_str(1.0e4), msg = str('Exect: {:9.2f}'.format(1.0e4)))
-        self.assertEqual(str('{:9.2e}'.format(1.0e-2)), format_number_to_str(1.0e-2), msg = str('Exect: {:9.2f}'.format(1.0e-2)))
             
 # --------------------------
 class SetupPriorMu(unittest.TestCase):

--- a/test/utilities/test_general.py
+++ b/test/utilities/test_general.py
@@ -6,6 +6,7 @@ Created on Tue Jun 26 06:17:24 2018
 @author: prmiles
 """
 from pymcmcstat.utilities.general import message, removekey, check_settings
+from pymcmcstat.utilities.general import format_number_to_str
 import unittest
 import io
 import sys
@@ -26,7 +27,16 @@ class MessageDisplay(unittest.TestCase):
         flag = message(verbosity = 0, level = 1, printthis = 'test')
         sys.stdout = sys.__stdout__                     # Reset redirect.
         self.assertFalse(flag, msg = 'Statement not printed because verbosity less than level')
+
         
+# --------------------------
+class FormatNumberToStr(unittest.TestCase):
+    def test_format_number_to_str(self):
+        self.assertEqual(str('{:9.2f}'.format(1.0)), format_number_to_str(1.0), msg = str('Exect: {:9.2f}'.format(1.0)))
+        self.assertEqual(str('{:9.2e}'.format(1.0e4)), format_number_to_str(1.0e4), msg = str('Exect: {:9.2f}'.format(1.0e4)))
+        self.assertEqual(str('{:9.2e}'.format(1.0e-2)), format_number_to_str(1.0e-2), msg = str('Exect: {:9.2f}'.format(1.0e-2)))
+
+
 # --------------------------
 class RemoveKey(unittest.TestCase):
     def test_removekey(self):


### PR DESCRIPTION
- for small numbers (~e-12) the display should correctly switch to a scientific format.
- Note, this could be improved to by letting the user control the level of accuracy, but for now the user can still access the raw data by specifying "returnstats=True" when calling the chainstats function.